### PR TITLE
Use configured repo_url during installation - Fixes Issue #7

### DIFF
--- a/setups/install.sh
+++ b/setups/install.sh
@@ -20,6 +20,8 @@ if [[ ! "$response" =~ ^[Yy][Ee][Ss]$ ]]; then
   exit 0
 fi
 
+export GITHUB_URL=$(yq '.repo_url' ./setups/config.yaml)
+
 # Set up ArgoCD. We will use ArgoCD to install all components.
 cd "${REPO_ROOT}/setups/argocd/"
 ./install.sh


### PR DESCRIPTION
Use the defined `repo_url` in `settings/config.yaml`. 

This fixes https://github.com/cnoe-io/reference-implementation-aws/issues/7.