### PR TITLE
Upgrade K8S to 1.28; EBS CSI to 1.25.0

### DIFF
--- a/eksctl.yaml
+++ b/eksctl.yaml
@@ -3,7 +3,7 @@ kind: ClusterConfig
 metadata:
   name: cnoe-ref-impl
   region: us-west-2
-  version: "1.27"
+  version: "1.28"
 managedNodeGroups:
   - name: managed-ng-1
     instanceType: m5.large
@@ -22,7 +22,7 @@ iam:
   withOIDC: true
 addons:
 - name: aws-ebs-csi-driver
-  version: "v1.20.0-eksbuild.1"
+  version: "v1.25.0-eksbuild.1"
   attachPolicyARNs:
   - arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy
 # iamIdentityMappings:


### PR DESCRIPTION
  New versions:

  Kubernetes 1.28 - Standard support until Nov. 2024
  EBS CSI 1.25.0

