### PR TITLE
Check for Kubeconfig file

### DIFF
--- a/setups/utils.sh
+++ b/setups/utils.sh
@@ -1,3 +1,4 @@
+set -e
 export RED='\033[0;31m'
 export GREEN='\033[0;32m'
 export PURPLE='\033[0;35m'
@@ -19,6 +20,32 @@ for cli in "${clis[@]}"; do
 done
 
 
+# Check if KUBECONFIG environment variable is set
+if [ -z "$KUBECONFIG" ]; then
+    DEFAULT_KUBECONFIG_FILE="$HOME/.kube/config"
+    echo "KUBECONFIG variable is not set. Checking $DEFAULT_KUBECONFIG_FILE kubeconfig file."
+
+    # Check if the default kubeconfig file exists
+    if [ ! -f "${DEFAULT_KUBECONFIG_FILE}" ]; then
+        echo "${DEFAULT_KUBECONFIG_FILE} kubeconfig file does not exist and KUBECONFIG environment variable is not set correctly."
+        exit 1
+    fi
+
+    if [ "$( grep  -v "^$\|^ *$" -c  "${DEFAULT_KUBECONFIG_FILE}" )" -eq "0" ]; then
+        echo -e "${RED}Error: ${DEFAULT_KUBECONFIG_FILE} kubeconfig file does not exist or is empty.${NC}"
+        echo -e "${PURPLE}Info: Please configure a valid kubeconfig file or set the KUBECONFIG environment variable.${NC}"
+        exit 1
+    fi
+
+else
+    # Check if the kubeconfig file specified in the environment variable exists
+    if [ ! -f "$KUBECONFIG" ]; then
+        echo -e "${RED}Specified kubeconfig file '${KUBECONFIG}' does not exist.${NC}"
+        exit 1
+    fi
+    export KUBECONFIG
+fi
+
 kubectl cluster-info > /dev/null
 if [ $? -ne 0 ]; then
   echo "Could not get cluster info. Ensure kubectl is configured correctly"
@@ -26,7 +53,7 @@ if [ $? -ne 0 ]; then
 fi
 
 minor=$(kubectl version --client=true -o yaml | yq '.clientVersion.minor')
-if [[ ${minor} -lt "27" ]]; then
-  echo -e "${RED}this kubectl version is not supported. Please upgrade to 1.27+ ${NC}"
+if [[ ${minor} -lt "20" ]]; then
+  echo -e "${RED} ${minor} this kubectl version is not supported. Please upgrade to 1.27+ ${NC}"
   exit 5
 fi

--- a/setups/utils.sh
+++ b/setups/utils.sh
@@ -53,7 +53,7 @@ if [ $? -ne 0 ]; then
 fi
 
 minor=$(kubectl version --client=true -o yaml | yq '.clientVersion.minor')
-if [[ ${minor} -lt "20" ]]; then
+if [[ ${minor} -lt "27" ]]; then
   echo -e "${RED} ${minor} this kubectl version is not supported. Please upgrade to 1.27+ ${NC}"
   exit 5
 fi


### PR DESCRIPTION
Added a check for the kubeconfig file in the utils.sh script. If the user is not familiar with configuring the kubeconfig file, error and informational logs will be provided to guide them through the process.