### PR TITLE
Fix keycloak ingress

### DIFF
--- a/packages/keycloak/dev/patches/deployment.yaml
+++ b/packages/keycloak/dev/patches/deployment.yaml
@@ -28,6 +28,8 @@ spec:
                 secretKeyRef:
                   name: postgresql-config
                   key: POSTGRES_PASSWORD
+            - name: KC_HOSTNAME
+              value: ${KEYCLOAK_DOMAIN_NAME}
           envFrom:
             - secretRef:
                 name: keycloak-config

--- a/terraform/keycloak.tf
+++ b/terraform/keycloak.tf
@@ -213,7 +213,7 @@ resource "kubectl_manifest" "application_argocd_keycloak" {
   )
 
   provisioner "local-exec" {
-    command = "./install.sh '${random_password.keycloak_user_password.result}' '${random_password.keycloak_admin_password.result}'"
+    command = "./install.sh '${random_password.keycloak_user_password.result}' '${random_password.keycloak_admin_password.result}' '${local.kc_domain_name}'"
 
     working_dir = "${path.module}/scripts/keycloak"
     interpreter = ["/bin/bash", "-c"]

--- a/terraform/scripts/keycloak/install.sh
+++ b/terraform/scripts/keycloak/install.sh
@@ -3,6 +3,7 @@ set -e -o pipefail
 
 export USER1_PASSWORD=${1}
 ADMIN_PASSWORD=${2}
+export KEYCLOAK_DOMAIN_NAME=${3}
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
 echo "waiting for keycloak to be ready. may take a few minutes"

--- a/terraform/templates/manifests/ingress-keycloak.yaml
+++ b/terraform/templates/manifests/ingress-keycloak.yaml
@@ -21,14 +21,14 @@ spec:
               service:
                 name: keycloak
                 port:
-                  number: 8081
+                  number: 8080
           - path: /
-            pathType: Exact
+            pathType: Prefix
             backend:
               service:
                 name: keycloak
                 port:
-                  number: 8081
+                  number: 8080
           - path: /realms
             pathType: Prefix
             backend:


### PR DESCRIPTION
On deploying CNOE, the keycloak ingress does not work properly. To fix the issue:
1) Set `KC_HOSTNAME` to the subdomain for `keycloak`
2) Port 8081 is not exposed by the `keycloak` service. Switch to port 8080
3) Set path `/` for `keycloak` ingress to match a Prefix, otherwise path based routing doesn't work. 

These changes are tested working in my EKS environment. 

I'm still trying to sort out how all the templating works, so please check my work on whether the value for `KC_HOSTNAME` is set correctly