### PR TITLE
Add Backstage self-service for prometeo's native components

### DIFF
--- a/cluster/eksctl/cluster-config-auto.yaml
+++ b/cluster/eksctl/cluster-config-auto.yaml
@@ -39,7 +39,7 @@ iam:
               - "secretsmanager:DescribeSecret"
               - "secretsmanager:ListSecretVersionIds"
             Resource:
-              - "arn:aws:secretsmanager:us-west-2:${AWS_ACCOUNT_ID}:secret:cnoe-ref-impl/*"
+              - "arn:aws:secretsmanager:eu-west-1:${AWS_ACCOUNT_ID}:secret:cnoe-ref-impl/*"
     - namespace: external-dns
       serviceAccountName: external-dns
       wellKnownPolicies:

--- a/cluster/eksctl/cluster-config.yaml
+++ b/cluster/eksctl/cluster-config.yaml
@@ -58,7 +58,7 @@ iam:
               - "secretsmanager:DescribeSecret"
               - "secretsmanager:ListSecretVersionIds"
             Resource:
-              - "arn:aws:secretsmanager:us-west-2:${AWS_ACCOUNT_ID}:secret:cnoe-ref-impl/*"
+              - "arn:aws:secretsmanager:eu-west-1:${AWS_ACCOUNT_ID}:secret:cnoe-ref-impl/*"
     - namespace: kube-system
       serviceAccountName: aws-load-balancer-controller
       wellKnownPolicies:

--- a/cluster/iam-policies/external-secrets.json
+++ b/cluster/iam-policies/external-secrets.json
@@ -18,7 +18,7 @@
         "secretsmanager:ListSecretVersionIds"
       ],
       "Resource": [
-        "arn:aws:secretsmanager:us-west-2:${AWS_ACCOUNT_ID}:secret:cnoe-ref-impl/*"
+        "arn:aws:secretsmanager:eu-west-1:${AWS_ACCOUNT_ID}:secret:cnoe-ref-impl/*"
       ]
     }
   ]

--- a/config.yaml
+++ b/config.yaml
@@ -3,23 +3,23 @@
 
 # Details of your repository fork
 repo: 
-  url: "https://github.com/cnoe-punkwalker/reference-implementation-aws" # This is the GITHUB URL of the fork in Github Org that you have created.
+  url: "https://github.com/crossplane-poc/reference-implementation-aws" # This is the GITHUB URL of the fork in Github Org that you have created.
   revision: "HEAD" # Branch or Tag which should be used for Argo CD Apps
   basepath: "packages" # Directory in which configuration of addons is stored
 
 # The name of the EKS cluster you are installing the reference implementation on.
-cluster_name: "cnoe-ref-impl"
+cluster_name: "ims-eu-west-1"
 # Set this to "true" if EKS cluster is Auto Mode othewise "false"
 # !!! Note: This is a string value as it is passed on to the Argo CD cluster secret as label
 auto_mode: "true"
 # AWS Region of the EKS cluster and cnoe-reference-implementation-aws config secret
-region: "us-west-2"
+region: "eu-west-1"
 
 # Base Domain name used for exposing services. It should be a subdomain or main domain of the Route53 hosted zone.
-domain: <REPLACE_ME_example.com>
+domain: "sb3.agents.iag.ai"
 
 # Route53 hosted zone ID for configuring external-dns
-route53_hosted_zone_id: <REPLACE_ME_ZXYZZ1234ABCDEF5GHIJKL>
+route53_hosted_zone_id: "Z0625912191R1GY8Y9405"
 
 # Set this to "true" if you want to enable path routing othewise "false" for domain based routing.
 # When enabled, the exposed addons will be accessible at https://<domain_name>/<addon-name> 
@@ -29,7 +29,7 @@ path_routing: "true"
 
 # Tags for AWS resources
 tags:
-  githubRepo: "github.com/cnoe-io/reference-implementation-aws"
-  env: "dev"
-  project: "cnoe"
+  githubRepo: "https://github.com/crossplane-poc/reference-implementation-aws"
+  env: "sb3"
+  project: "cnoe-poc"
   

--- a/config.yaml
+++ b/config.yaml
@@ -16,7 +16,7 @@ auto_mode: "true"
 region: "eu-west-1"
 
 # Base Domain name used for exposing services. It should be a subdomain or main domain of the Route53 hosted zone.
-domain: "sb3.agents.iag.ai"
+domain: "sb3.ims.iag.ai"
 
 # Route53 hosted zone ID for configuring external-dns
 route53_hosted_zone_id: "Z0625912191R1GY8Y9405"

--- a/packages/argo-cd/manifests/applicationset-prometeo-products.yaml
+++ b/packages/argo-cd/manifests/applicationset-prometeo-products.yaml
@@ -1,0 +1,36 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: prometeo-products
+  namespace: argocd
+spec:
+  generators:
+    - git:
+        repoURL: https://github.com/crossplane-poc/prometeo-products.git
+        revision: main
+        directories:
+          - path: products/*/envs/sb3
+  template:
+    metadata:
+      name: 'prometeo-{{path[1]}}-sb3'
+    spec:
+      project: prometeo-products
+      source:
+        repoURL: https://github.com/crossplane-poc/prometeo-products.git
+        targetRevision: main
+        path: '{{path}}'
+      destination:
+        server: https://kubernetes.default.svc
+      syncPolicy:
+        # No `automated:` block, on purpose — merging a product's PR must not deploy it. Sync is
+        # a manual, deliberate action (ArgoCD UI/CLI or Backstage's ArgoCD plugin), not a side
+        # effect of a merge.
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true
+        retry:
+          limit: -1
+          backoff:
+            duration: 5s
+            factor: 2
+            maxDuration: 10m

--- a/packages/argo-cd/manifests/appproject-prometeo-products.yaml
+++ b/packages/argo-cd/manifests/appproject-prometeo-products.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: prometeo-products
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  description: >-
+    Products scaffolded from Backstage's prometeo-* templates (AppService/PostgresDatabase/
+    StatefulBackend/ObjectStore instances from crossplane-poc/prometeo-products). Namespace is
+    left wildcarded because each component creates its own service-named namespace
+    (products/README.md: one namespace per service, not per product) and those names aren't
+    known in advance.
+  sourceRepos:
+    - 'https://github.com/crossplane-poc/prometeo-products.git'
+  clusterResourceWhitelist:
+    - group: '*'
+      kind: '*'
+  destinations:
+    - namespace: '*'
+      server: https://kubernetes.default.svc

--- a/packages/argo-cd/values.yaml
+++ b/packages/argo-cd/values.yaml
@@ -3,7 +3,21 @@ cnoe_ref_impl:
   auto_mode: '"true"'
 dex:
   enabled: false
+controller:
+  resources:
+    requests:
+      cpu: 200m
+      memory: 512Mi
+repoServer:
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
 server:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
   ingress:
     enabled: true
     ingressClassName: "nginx"

--- a/packages/backstage/values.yaml
+++ b/packages/backstage/values.yaml
@@ -119,8 +119,14 @@ backstage:
               password: ${ARGOCD_ADMIN_PASSWORD}
     argoWorkflows:
       baseUrl: ${ARGO_WORKFLOWS_URL}
+global:
+  security:
+    allowInsecureImages: true
 postgresql:
   enabled: true
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/postgresql
   auth:
     username: "backstage"
     existingSecret: "backstage-env-vars"

--- a/packages/crossplane-aws-upbound/values.yaml
+++ b/packages/crossplane-aws-upbound/values.yaml
@@ -33,8 +33,8 @@ provider:
     annotations: {}
     labels: {}
   package:
-    registry: xpkg.crossplane.io/crossplane-contrib
-    version: v1.23.0
+    registry: xpkg.upbound.io/upbound
+    version: v2.7.0
 
 providerConfig:
   enabled: true

--- a/packages/external-secrets/manifests/cluster-secret-store.yaml
+++ b/packages/external-secrets/manifests/cluster-secret-store.yaml
@@ -6,4 +6,4 @@ spec:
   provider:
     aws:
       service: SecretsManager
-      region: us-west-2
+      region: eu-west-1

--- a/packages/keycloak/manifests/user-sso-config-job.yaml
+++ b/packages/keycloak/manifests/user-sso-config-job.yaml
@@ -59,6 +59,7 @@ metadata:
   namespace: keycloak
   annotations:
     argocd.argoproj.io/sync-wave: "40"
+    canary-check: "v2"
 data:
   client-scope-groups-payload.json: |
     {

--- a/packages/keycloak/manifests/user-sso-config-job.yaml
+++ b/packages/keycloak/manifests/user-sso-config-job.yaml
@@ -59,7 +59,6 @@ metadata:
   namespace: keycloak
   annotations:
     argocd.argoproj.io/sync-wave: "40"
-    canary-check: "v2"
 data:
   client-scope-groups-payload.json: |
     {

--- a/packages/keycloak/manifests/user-sso-config-job.yaml
+++ b/packages/keycloak/manifests/user-sso-config-job.yaml
@@ -247,6 +247,12 @@ spec:
           envFrom:
             - secretRef:
                 name: keycloak-config
+          env:
+            - name: KEYCLOAK_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-admin-password-actual
+                  key: KEYCLOAK_ADMIN_PASSWORD
           command: ["/bin/bash", "-c"]
           args:
             - |
@@ -322,7 +328,7 @@ spec:
               fi
 
               # Download kubectl
-              curl -sS -LO "https://dl.k8s.io/release/v1.28.3//bin/linux/amd64/kubectl"
+              curl -sS -LO "https://dl.k8s.io/release/v1.28.3/bin/linux/amd64/kubectl"
               chmod +x kubectl
               
               echo "creating client scopes"

--- a/packages/keycloak/values.yaml
+++ b/packages/keycloak/values.yaml
@@ -6,6 +6,10 @@ proxyHeaders: "forwarded"
 global:
   defaultStorageClass: gp3
 
+image:
+  registry: docker.io
+  repository: bitnamilegacy/keycloak
+
 auth:
   adminUser: cnoe-admin
   adminPassword: cnoe-admin
@@ -23,6 +27,9 @@ ingress:
 
 postgresql:
   enabled: true
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/postgresql
   auth:
     username: keycloak
     database: keycloak

--- a/packages/keycloak/values.yaml
+++ b/packages/keycloak/values.yaml
@@ -5,6 +5,8 @@ proxyHeaders: "forwarded"
 
 global:
   defaultStorageClass: gp3
+  security:
+    allowInsecureImages: true
 
 image:
   registry: docker.io

--- a/templates/backstage/catalog-info.yaml
+++ b/templates/backstage/catalog-info.yaml
@@ -13,6 +13,30 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Location
 metadata:
+  name: prometeo-templates
+  description: >-
+    Backstage templates for Prometeo's native Crossplane components (service, database,
+    statefulbackend, s3), PR-ing generated manifests into crossplane-poc/prometeo-products.
+spec:
+  targets:
+    - ./prometeo-product/template.yaml
+    - ./prometeo-service/template.yaml
+    - ./prometeo-database/template.yaml
+    - ./prometeo-statefulbackend/template.yaml
+    - ./prometeo-s3/template.yaml
+---
+apiVersion: backstage.io/v1alpha1
+kind: Location
+metadata:
+  name: prometeo-products-catalog
+  description: Discovers a System entity per product scaffolded into crossplane-poc/prometeo-products
+spec:
+  type: url
+  target: https://github.com/crossplane-poc/prometeo-products/blob/main/catalog-info.yaml
+---
+apiVersion: backstage.io/v1alpha1
+kind: Location
+metadata:
   name: basic-organization
   description: Basic organization data
 spec:

--- a/templates/backstage/prometeo-database/template.yaml
+++ b/templates/backstage/prometeo-database/template.yaml
@@ -1,0 +1,163 @@
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: prometeo-database
+  title: "Prometeo: database"
+  description: >-
+    An Aurora PostgreSQL Serverless v2 cluster — a Prometeo PostgresDatabase. Replaces
+    tf-common-modules/modules/rds. Use this only for a database shared by more than one service;
+    a database private to one backend belongs on prometeo-statefulbackend instead. The product
+    must already exist (run prometeo-product first) with this file's name listed in its
+    componentFiles.
+  tags:
+    - prometeo
+spec:
+  owner: guests
+  type: resource
+  parameters:
+    - title: Placement
+      required:
+        - name
+        - product
+        - namespace
+      properties:
+        name:
+          title: Database component name
+          type: string
+          description: e.g. "db". Becomes the XR name.
+          pattern: '^[a-z][a-z0-9-]*$'
+          ui:autofocus: true
+        product:
+          title: Product
+          type: string
+          description: The product this database belongs to (must already exist in prometeo-products).
+        namespace:
+          title: Namespace
+          type: string
+          description: >-
+            Shared by more than one service? Use "<product>-<name>" (e.g. "cms-db") and it'll be
+            created for you. Private to one service? Use that service's own namespace instead —
+            and prefer prometeo-statefulbackend, which bundles this for you.
+        databaseName:
+          title: Database name inside the cluster
+          type: string
+          description: Defaults to "<product>db" (hyphens removed) when left blank.
+    - title: Sizing and access
+      properties:
+        engineVersion:
+          title: Aurora PostgreSQL version
+          type: string
+        minACU:
+          title: Min ACU
+          type: number
+        maxACU:
+          title: Max ACU
+          type: number
+        instances:
+          title: Instances
+          type: integer
+          default: 1
+          description: 1 for single-AZ, 2 for HA.
+        schemas:
+          title: Schemas to create at bootstrap
+          type: array
+          items:
+            type: string
+          default: []
+        access:
+          title: Service access
+          type: array
+          description: Services allowed to authenticate with IAM against this database.
+          items:
+            type: object
+            required: [service]
+            properties:
+              service:
+                type: string
+              level:
+                type: string
+                enum: [connect, admin]
+                default: connect
+          default: []
+        backupRetentionDays:
+          title: Backup retention (days)
+          type: integer
+          default: 7
+        deletionProtection:
+          title: Deletion protection
+          type: boolean
+          default: false
+          description: Leave off outside prd — turning it on blocks deletion until it's turned off again.
+
+  steps:
+    - id: write-component
+      name: Write the PostgresDatabase manifest
+      action: roadiehq:utils:fs:write
+      input:
+        path: products/${{ values.product }}/base/${{ values.name }}.yaml
+        content: |
+          # The Namespace object is repeated harmlessly if this database shares a namespace with
+          # another component already declaring it (kustomize/kubectl apply is idempotent on an
+          # identical object) — kept self-contained per file rather than centralized, since
+          # Backstage template runs are stateless and can't append to a shared namespaces.yaml.
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: ${{ values.namespace }}
+            labels:
+              name: ${{ values.namespace }}
+              product: ${{ values.product }}
+              platform: prometeo
+          ---
+          apiVersion: platform.prometeo.iag.ai/v1alpha1
+          kind: PostgresDatabase
+          metadata:
+            name: ${{ values.name }}
+            namespace: ${{ values.namespace }}
+          spec:
+            product: ${{ values.product }}
+          {% if values.databaseName %}
+            databaseName: {{ values.databaseName | dump }}
+          {% endif %}
+          {% if values.engineVersion %}
+            engineVersion: {{ values.engineVersion | dump }}
+          {% endif %}
+          {% if values.schemas and values.schemas | length %}
+            schemas:
+          {% for s in values.schemas %}
+              - {{ s }}
+          {% endfor %}
+          {% endif %}
+            capacity:
+              instances: ${{ values.instances }}
+          {% if values.minACU %}
+              minACU: {{ values.minACU }}
+          {% endif %}
+          {% if values.maxACU %}
+              maxACU: {{ values.maxACU }}
+          {% endif %}
+          {% if values.access and values.access | length %}
+            access:
+          {% for a in values.access %}
+              - service: {{ a.service }}
+                level: {{ a.level }}
+          {% endfor %}
+          {% endif %}
+            backupRetentionDays: ${{ values.backupRetentionDays }}
+            deletionProtection: ${{ values.deletionProtection }}
+
+    - id: publish
+      name: Open a PR with the new database
+      action: publish:github:pull-request
+      input:
+        repoUrl: github.com?repo=prometeo-products&owner=crossplane-poc
+        branchName: scaffolder/database-${{ values.product }}-${{ values.name }}
+        title: 'prometeo database: ${{ values.product }}/${{ values.name }}'
+        description: >-
+          Adds `products/${{ values.product }}/base/${{ values.name }}.yaml` (PostgresDatabase)
+          via the prometeo-database Backstage template.
+
+  output:
+    links:
+      - title: Open PR
+        url: ${{ steps['publish'].output.remoteUrl }}

--- a/templates/backstage/prometeo-product/template.yaml
+++ b/templates/backstage/prometeo-product/template.yaml
@@ -1,0 +1,105 @@
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: prometeo-product
+  title: "Prometeo: bootstrap a product"
+  description: >-
+    Step 1 for a new product built from Prometeo's native Crossplane components. Creates the
+    product's skeleton (Kustomize base + sb3 overlay + a Backstage System entity) in
+    crossplane-poc/prometeo-products. Run this once per product, before adding any service,
+    database, statefulbackend or s3 component to it.
+  tags:
+    - prometeo
+spec:
+  owner: guests
+  type: service
+  parameters:
+    - title: Product
+      required:
+        - name
+        - componentFiles
+      properties:
+        name:
+          title: Product name
+          type: string
+          description: Short lowercase name, e.g. "add". Used as the product tag and the folder name.
+          pattern: '^[a-z][a-z0-9-]*$'
+          ui:autofocus: true
+        description:
+          title: Description
+          type: string
+          description: Shown on the product's Backstage System entity.
+        componentFiles:
+          title: Component files
+          type: array
+          description: >-
+            Filenames you're about to add with the prometeo-service / prometeo-database /
+            prometeo-statefulbackend / prometeo-s3 templates, e.g. ["add-fe.yaml", "add-be.yaml"].
+            Kustomize needs the full list up front — add the matching component right after this
+            PR merges, using exactly these filenames.
+          items:
+            type: string
+          minItems: 1
+
+  steps:
+    - id: write-kustomization
+      name: Write base kustomization.yaml
+      action: roadiehq:utils:fs:write
+      input:
+        path: products/${{ values.name }}/base/kustomization.yaml
+        content: |
+          # ${{ values.name }}, independent of environment. Per-environment values live in ../envs/<env>.
+          apiVersion: kustomize.config.k8s.io/v1beta1
+          kind: Kustomization
+
+          resources:
+          {% for f in values.componentFiles %}
+            - {{ f }}
+          {% endfor %}
+
+    - id: write-catalog-info
+      name: Write the product's System entity
+      action: roadiehq:utils:fs:write
+      input:
+        path: products/${{ values.name }}/base/catalog-info.yaml
+        content: |
+          apiVersion: backstage.io/v1alpha1
+          kind: System
+          metadata:
+            name: ${{ values.name }}
+            description: ${{ (values.description | default('Prometeo product ' + values.name)) | dump }}
+            annotations:
+              backstage.io/kubernetes-label-selector: 'product=${{ values.name }},platform=prometeo'
+          spec:
+            owner: guests
+            lifecycle: experimental
+            type: service
+
+    - id: write-env-kustomization
+      name: Write the sb3 overlay
+      action: roadiehq:utils:fs:write
+      input:
+        path: products/${{ values.name }}/envs/sb3/kustomization.yaml
+        content: |
+          # ${{ values.name }} in sb3.
+          apiVersion: kustomize.config.k8s.io/v1beta1
+          kind: Kustomization
+
+          resources:
+            - ../../base
+
+    - id: publish
+      name: Open a PR with the new product skeleton
+      action: publish:github:pull-request
+      input:
+        repoUrl: github.com?repo=prometeo-products&owner=crossplane-poc
+        branchName: scaffolder/product-${{ values.name }}
+        title: 'prometeo product: bootstrap ${{ values.name }}'
+        description: >-
+          Bootstraps `products/${{ values.name }}/` (base + sb3 overlay + System entity), via the
+          prometeo-product Backstage template. Add ${{ values.componentFiles | join(', ') }} next.
+
+  output:
+    links:
+      - title: Open PR
+        url: ${{ steps['publish'].output.remoteUrl }}

--- a/templates/backstage/prometeo-s3/template.yaml
+++ b/templates/backstage/prometeo-s3/template.yaml
@@ -1,0 +1,120 @@
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: prometeo-s3
+  title: "Prometeo: s3"
+  description: >-
+    One S3 bucket, encrypted with its own key, private, versioned — a Prometeo ObjectStore.
+    Replaces tf-common-modules/modules/s3 plus its per-product IAM access policy. The product
+    must already exist (run prometeo-product first) with this file's name listed in its
+    componentFiles.
+  tags:
+    - prometeo
+spec:
+  owner: guests
+  type: resource
+  parameters:
+    - title: Placement
+      required:
+        - name
+        - product
+        - namespace
+      properties:
+        name:
+          title: Bucket component name
+          type: string
+          description: e.g. "exports". Becomes the XR name.
+          pattern: '^[a-z][a-z0-9-]*$'
+          ui:autofocus: true
+        product:
+          title: Product
+          type: string
+          description: The product this bucket belongs to (must already exist in prometeo-products).
+        namespace:
+          title: Namespace
+          type: string
+          description: >-
+            Granted to one service only? Use that service's own namespace. Shared by more than
+            one? Use "<product>-<name>" instead.
+        bucketName:
+          title: Bucket name
+          type: string
+          description: >-
+            Full bucket name. Defaults to prometeo-<env>-<product>-<component> when left blank —
+            S3 names are globally unique, so set this if the default is already taken.
+    - title: Lifecycle and access
+      properties:
+        expirationDays:
+          title: Expire objects after (days)
+          type: integer
+          description: Leave blank to keep objects forever.
+        access:
+          title: Service access
+          type: array
+          items:
+            type: object
+            required: [service]
+            properties:
+              service:
+                type: string
+              level:
+                type: string
+                enum: [ro, rw]
+                default: rw
+          default: []
+
+  steps:
+    - id: write-component
+      name: Write the ObjectStore manifest
+      action: roadiehq:utils:fs:write
+      input:
+        path: products/${{ values.product }}/base/${{ values.name }}.yaml
+        content: |
+          # The Namespace object is repeated harmlessly if this bucket shares a namespace with
+          # another component already declaring it (kustomize/kubectl apply is idempotent on an
+          # identical object).
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: ${{ values.namespace }}
+            labels:
+              name: ${{ values.namespace }}
+              product: ${{ values.product }}
+              platform: prometeo
+          ---
+          apiVersion: platform.prometeo.iag.ai/v1alpha1
+          kind: ObjectStore
+          metadata:
+            name: ${{ values.name }}
+            namespace: ${{ values.namespace }}
+          spec:
+            product: ${{ values.product }}
+          {% if values.bucketName %}
+            bucketName: {{ values.bucketName | dump }}
+          {% endif %}
+          {% if values.expirationDays %}
+            expirationDays: ${{ values.expirationDays }}
+          {% endif %}
+          {% if values.access and values.access | length %}
+            access:
+          {% for a in values.access %}
+              - service: {{ a.service }}
+                level: {{ a.level }}
+          {% endfor %}
+          {% endif %}
+
+    - id: publish
+      name: Open a PR with the new bucket
+      action: publish:github:pull-request
+      input:
+        repoUrl: github.com?repo=prometeo-products&owner=crossplane-poc
+        branchName: scaffolder/s3-${{ values.product }}-${{ values.name }}
+        title: 'prometeo s3: ${{ values.product }}/${{ values.name }}'
+        description: >-
+          Adds `products/${{ values.product }}/base/${{ values.name }}.yaml` (ObjectStore) via
+          the prometeo-s3 Backstage template.
+
+  output:
+    links:
+      - title: Open PR
+        url: ${{ steps['publish'].output.remoteUrl }}

--- a/templates/backstage/prometeo-service/template.yaml
+++ b/templates/backstage/prometeo-service/template.yaml
@@ -1,0 +1,221 @@
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: prometeo-service
+  title: "Prometeo: service"
+  description: >-
+    One runnable service (a Deployment, its AWS identity, its network rules) — a Prometeo
+    AppService. Replaces tf-common-modules/modules/bootstrap-service. The product must already
+    exist (run prometeo-product first) with this file's name listed in its componentFiles.
+  tags:
+    - prometeo
+spec:
+  owner: guests
+  type: service
+  parameters:
+    - title: Placement
+      required:
+        - name
+        - product
+        - image
+      properties:
+        name:
+          title: Service name
+          type: string
+          description: >-
+            e.g. "add-fe". Becomes the XR name and its own namespace (one namespace per service,
+            not per product) — must match a filename you listed in the product's componentFiles.
+          pattern: '^[a-z][a-z0-9-]*$'
+          ui:autofocus: true
+        product:
+          title: Product
+          type: string
+          description: The product this service belongs to (must already exist in prometeo-products).
+        image:
+          title: Container image
+          type: string
+          description: Full image ref including tag or digest.
+        containerPort:
+          title: Container port
+          type: integer
+          default: 8080
+          description: Backends typically use 8000/8001, frontends 3000.
+        replicas:
+          title: Replicas
+          type: integer
+    - title: Runtime
+      properties:
+        env:
+          title: Environment variables
+          type: object
+          additionalProperties:
+            type: string
+          default: {}
+        connections:
+          title: Datastore connections
+          type: array
+          description: >-
+            Names of datastore components in this same namespace to mount (their
+            <name>-connection ConfigMap), e.g. ["db"].
+          items:
+            type: string
+          default: []
+        migrationsEnabled:
+          title: Run schema migrations before rollout
+          type: boolean
+          default: false
+    - title: AWS access
+      description: Opens the matching VPC interface endpoint's NetworkPolicy.
+      properties:
+        awsBedrock:
+          title: Bedrock
+          type: boolean
+          default: false
+        awsS3:
+          title: S3
+          type: boolean
+          default: false
+        awsSqs:
+          title: SQS
+          type: boolean
+          default: false
+        awsDynamodb:
+          title: DynamoDB
+          type: boolean
+          default: false
+    - title: Ingress
+      properties:
+        ingressEnabled:
+          title: Expose through the shared ALB
+          type: boolean
+          default: false
+        ingressHost:
+          title: Host
+          type: string
+          description: Defaults to <product>.<environment domain> when left blank.
+        ingressDnsRecord:
+          title: Point DNS at the ALB
+          type: boolean
+          default: true
+          description: Set false when an SsoEndpoint fronts this service instead.
+        healthcheckPath:
+          title: Health check path
+          type: string
+          default: /health
+    - title: Network
+      description: Everything is denied by default; each entry opens one direction, to one peer, on one port.
+      properties:
+        allowFrom:
+          title: Allow from
+          type: array
+          items:
+            type: object
+            required: [service, port]
+            properties:
+              service:
+                type: string
+              port:
+                type: integer
+          default: []
+        allowTo:
+          title: Allow to
+          type: array
+          items:
+            type: object
+            required: [service, port]
+            properties:
+              service:
+                type: string
+              port:
+                type: integer
+          default: []
+
+  steps:
+    - id: write-component
+      name: Write the AppService manifest
+      action: roadiehq:utils:fs:write
+      input:
+        path: products/${{ values.product }}/base/${{ values.name }}.yaml
+        content: |
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: ${{ values.name }}
+            labels:
+              name: ${{ values.name }}
+              service: ${{ values.name }}
+              product: ${{ values.product }}
+              platform: prometeo
+              admission.datadoghq.com/enabled: "true"
+          ---
+          apiVersion: platform.prometeo.iag.ai/v1alpha1
+          kind: AppService
+          metadata:
+            name: ${{ values.name }}
+            namespace: ${{ values.name }}
+          spec:
+            product: ${{ values.product }}
+            image: ${{ values.image | dump }}
+            containerPort: ${{ values.containerPort }}
+          {% if values.replicas %}
+            replicas: {{ values.replicas }}
+          {% endif %}
+          {% if values.env and values.env | length %}
+            env:
+          {% for k, v in values.env %}
+              {{ k }}: {{ v | dump }}
+          {% endfor %}
+          {% endif %}
+          {% if values.connections and values.connections | length %}
+            connections:
+          {% for c in values.connections %}
+              - {{ c }}
+          {% endfor %}
+          {% endif %}
+            migrations:
+              enabled: ${{ values.migrationsEnabled }}
+            aws:
+              bedrock: ${{ values.awsBedrock }}
+              s3: ${{ values.awsS3 }}
+              sqs: ${{ values.awsSqs }}
+              dynamodb: ${{ values.awsDynamodb }}
+            ingress:
+              enabled: ${{ values.ingressEnabled }}
+          {% if values.ingressHost %}
+              host: {{ values.ingressHost | dump }}
+          {% endif %}
+              dnsRecord: ${{ values.ingressDnsRecord }}
+              healthcheckPath: ${{ values.healthcheckPath | dump }}
+          {% if (values.allowFrom and values.allowFrom | length) or (values.allowTo and values.allowTo | length) %}
+            network:
+          {% if values.allowFrom and values.allowFrom | length %}
+              allowFrom:
+          {% for r in values.allowFrom %}
+                - service: {{ r.service }}
+                  port: {{ r.port }}
+          {% endfor %}
+          {% endif %}
+          {% if values.allowTo and values.allowTo | length %}
+              allowTo:
+          {% for r in values.allowTo %}
+                - service: {{ r.service }}
+                  port: {{ r.port }}
+          {% endfor %}
+          {% endif %}
+          {% endif %}
+
+    - id: publish
+      name: Open a PR with the new service
+      action: publish:github:pull-request
+      input:
+        repoUrl: github.com?repo=prometeo-products&owner=crossplane-poc
+        branchName: scaffolder/service-${{ values.name }}
+        title: 'prometeo service: ${{ values.name }}'
+        description: >-
+          Adds `products/${{ values.product }}/base/${{ values.name }}.yaml` (Namespace +
+          AppService) via the prometeo-service Backstage template.
+
+  output:
+    links:
+      - title: Open PR
+        url: ${{ steps['publish'].output.remoteUrl }}

--- a/templates/backstage/prometeo-statefulbackend/template.yaml
+++ b/templates/backstage/prometeo-statefulbackend/template.yaml
@@ -1,0 +1,228 @@
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: prometeo-statefulbackend
+  title: "Prometeo: statefulbackend"
+  description: >-
+    A backend and the database it owns, as one bundle — a Prometeo StatefulBackend. Use this when
+    a backend owns its database exclusively; when several services share one database, use
+    prometeo-service plus a separate prometeo-database instead. The product must already exist
+    (run prometeo-product first) with this file's name listed in its componentFiles.
+  tags:
+    - prometeo
+spec:
+  owner: guests
+  type: service
+  parameters:
+    - title: Placement
+      required:
+        - name
+        - product
+        - image
+      properties:
+        name:
+          title: Service name
+          type: string
+          description: >-
+            e.g. "add-be". Becomes the XR name and its own namespace, shared with the database it
+            owns — must match a filename you listed in the product's componentFiles.
+          pattern: '^[a-z][a-z0-9-]*$'
+          ui:autofocus: true
+        product:
+          title: Product
+          type: string
+          description: The product this backend belongs to (must already exist in prometeo-products).
+        image:
+          title: Container image
+          type: string
+        containerPort:
+          title: Container port
+          type: integer
+          default: 8000
+        replicas:
+          title: Replicas
+          type: integer
+    - title: Runtime
+      properties:
+        env:
+          title: Environment variables
+          type: object
+          additionalProperties:
+            type: string
+          default: {}
+        migrationsEnabled:
+          title: Run schema migrations before rollout
+          type: boolean
+          default: false
+    - title: AWS access
+      properties:
+        awsBedrock:
+          title: Bedrock
+          type: boolean
+          default: false
+        awsS3:
+          title: S3
+          type: boolean
+          default: false
+        awsSqs:
+          title: SQS
+          type: boolean
+          default: false
+        awsDynamodb:
+          title: DynamoDB
+          type: boolean
+          default: false
+    - title: Network
+      properties:
+        allowFrom:
+          title: Allow from
+          type: array
+          items:
+            type: object
+            required: [service, port]
+            properties:
+              service:
+                type: string
+              port:
+                type: integer
+          default: []
+        allowTo:
+          title: Allow to
+          type: array
+          items:
+            type: object
+            required: [service, port]
+            properties:
+              service:
+                type: string
+              port:
+                type: integer
+          default: []
+    - title: Its database
+      properties:
+        databaseName:
+          title: Database name inside the cluster
+          type: string
+          description: Defaults to "<product>db" (hyphens removed) when left blank.
+        engineVersion:
+          title: Aurora PostgreSQL version
+          type: string
+        minACU:
+          title: Min ACU
+          type: number
+        maxACU:
+          title: Max ACU
+          type: number
+        instances:
+          title: Instances
+          type: integer
+          default: 1
+        schemas:
+          title: Schemas to create at bootstrap
+          type: array
+          items:
+            type: string
+          default: []
+        deletionProtection:
+          title: Deletion protection
+          type: boolean
+          default: false
+
+  steps:
+    - id: write-component
+      name: Write the StatefulBackend manifest
+      action: roadiehq:utils:fs:write
+      input:
+        path: products/${{ values.product }}/base/${{ values.name }}.yaml
+        content: |
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: ${{ values.name }}
+            labels:
+              name: ${{ values.name }}
+              service: ${{ values.name }}
+              product: ${{ values.product }}
+              platform: prometeo
+              admission.datadoghq.com/enabled: "true"
+          ---
+          apiVersion: platform.prometeo.iag.ai/v1alpha1
+          kind: StatefulBackend
+          metadata:
+            name: ${{ values.name }}
+            namespace: ${{ values.name }}
+          spec:
+            product: ${{ values.product }}
+            image: ${{ values.image | dump }}
+            containerPort: ${{ values.containerPort }}
+          {% if values.replicas %}
+            replicas: {{ values.replicas }}
+          {% endif %}
+          {% if values.env and values.env | length %}
+            env:
+          {% for k, v in values.env %}
+              {{ k }}: {{ v | dump }}
+          {% endfor %}
+          {% endif %}
+            migrations:
+              enabled: ${{ values.migrationsEnabled }}
+            aws:
+              bedrock: ${{ values.awsBedrock }}
+              s3: ${{ values.awsS3 }}
+              sqs: ${{ values.awsSqs }}
+              dynamodb: ${{ values.awsDynamodb }}
+          {% if (values.allowFrom and values.allowFrom | length) or (values.allowTo and values.allowTo | length) %}
+            network:
+          {% if values.allowFrom and values.allowFrom | length %}
+              allowFrom:
+          {% for r in values.allowFrom %}
+                - service: {{ r.service }}
+                  port: {{ r.port }}
+          {% endfor %}
+          {% endif %}
+          {% if values.allowTo and values.allowTo | length %}
+              allowTo:
+          {% for r in values.allowTo %}
+                - service: {{ r.service }}
+                  port: {{ r.port }}
+          {% endfor %}
+          {% endif %}
+          {% endif %}
+            database:
+          {% if values.databaseName %}
+              databaseName: {{ values.databaseName | dump }}
+          {% endif %}
+          {% if values.engineVersion %}
+              engineVersion: {{ values.engineVersion | dump }}
+          {% endif %}
+          {% if values.schemas and values.schemas | length %}
+              schemas:
+          {% for s in values.schemas %}
+                - {{ s }}
+          {% endfor %}
+          {% endif %}
+              capacity:
+                instances: ${{ values.instances }}
+          {% if values.minACU %}
+                minACU: {{ values.minACU }}
+          {% endif %}
+          {% if values.maxACU %}
+                maxACU: {{ values.maxACU }}
+          {% endif %}
+              deletionProtection: ${{ values.deletionProtection }}
+
+    - id: publish
+      name: Open a PR with the new statefulbackend
+      action: publish:github:pull-request
+      input:
+        repoUrl: github.com?repo=prometeo-products&owner=crossplane-poc
+        branchName: scaffolder/statefulbackend-${{ values.name }}
+        title: 'prometeo statefulbackend: ${{ values.name }}'
+        description: >-
+          Adds `products/${{ values.product }}/base/${{ values.name }}.yaml` (Namespace +
+          StatefulBackend) via the prometeo-statefulbackend Backstage template.
+
+  output:
+    links:
+      - title: Open PR
+        url: ${{ steps['publish'].output.remoteUrl }}


### PR DESCRIPTION
## Summary
- Exposes 4 of prometeo's native Crossplane components as Backstage Software Templates: `prometeo-service` (AppService), `prometeo-database` (PostgresDatabase), `prometeo-statefulbackend` (StatefulBackend), `prometeo-s3` (ObjectStore) — plus `prometeo-product` to bootstrap a new product's skeleton first.
- Each template opens a PR into `crossplane-poc/prometeo-products` (new repo) rather than pushing directly.
- Adds `prometeo-products` AppProject + a directory-generator ApplicationSet watching `products/*/envs/sb3` in that repo, so a merged product shows up as an ArgoCD Application.
- **No automated sync policy** on the ApplicationSet, on purpose — merging a template's PR must not deploy anything by itself. Syncing (actually applying to the cluster) is a separate, manual action from the ArgoCD UI/CLI or Backstage's ArgoCD plugin.

## Context
The underlying platform this depends on is already live on `ims-eu-west-1` — Crossplane 2.3.4, all AWS providers, both `prometeo-crossplane-provider`/`prometeo-terraform-provider` IAM roles, and the full native+terraform XRD catalog — applied manually (`make install` style), not via GitOps. This PR doesn't touch any of that; it only adds the Backstage-facing scaffolding on top so new product components can be authored through the catalog instead of hand-written YAML.

Only 4 of prometeo's native components are exposed (service/database/statefulbackend/s3) — sso-endpoint, key-value-table, message-queue, scheduled-jobs, agent-jobs, and the entire terraform-backed component path are out of scope for this round.

## Test plan
- [ ] Merge and confirm the 5 templates appear under Backstage → Create
- [ ] Run `prometeo-product` for a throwaway product name, confirm the PR against `crossplane-poc/prometeo-products` looks right, close without merging
- [ ] Run `prometeo-service` similarly, confirm the generated `Namespace` + `AppService` YAML is well-formed
- [ ] Confirm the `prometeo-products` ApplicationSet + AppProject show up in ArgoCD (`kubectl get applicationset,appproject -n argocd`) with no Applications yet (no products merged)
- [ ] When ready to actually deploy something (e.g. ADD), scaffold its files through the templates and sync the resulting Application manually